### PR TITLE
Account for <base> tag when calculating integrity.

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,9 @@ SRIHashAssets.prototype.getBaseHREF = function getBaseHREF(string) {
 
     if (!relativePath) { return null; }
 
+    // do not support `<base href="../../">`
+    if (!relativePath[0] === '/') { return null; }
+
     return this.inputPaths[0] + relativePath;
   }
 

--- a/test/fixtures/input/foo/test.html
+++ b/test/fixtures/input/foo/test.html
@@ -1,3 +1,5 @@
+<base href="/">
+
 <!-- styles -->
 <link rel="stylesheet" href="https://example.com/thing.css">
 <link rel="stylesheet" href="https://example.com/thing.css">

--- a/test/fixtures/output/foo/test.html
+++ b/test/fixtures/output/foo/test.html
@@ -1,3 +1,5 @@
+<base href="/">
+
 <!-- styles -->
 <link rel="stylesheet" href="https://example.com/thing.css">
 <link rel="stylesheet" href="https://example.com/thing.css">

--- a/test/index.js
+++ b/test/index.js
@@ -26,8 +26,15 @@ describe('broccoli-sri-hash', function () {
 
   it('rule outputs match (initial build)', function () {
     return builder.build().then(function(output) {
-      var actual = file(output.directory + '/test.html');
-      var expected = file('test/fixtures/output/test.html');
+      var actual, expected;
+
+      actual = file(output.directory + '/test.html');
+      expected = file('test/fixtures/output/test.html');
+
+      assert.equal(actual, expected);
+
+      actual = file(output.directory + '/foo/test.html');
+      expected = file('test/fixtures/output/foo/test.html');
 
       assert.equal(actual, expected);
 


### PR DESCRIPTION
Fixes #12.
