### PR TITLE
Make snyk a dev dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "broccoli-caching-writer": "^2.2.0",
     "mkdirp": "^0.5.1",
     "rsvp": "^3.1.0",
-    "snyk": "^1.1.0",
     "sri-toolbox": "^0.2.0",
     "symlink-or-copy": "^1.0.1"
   },
@@ -29,6 +28,7 @@
     "eslint-config-nightmare-mode": "0.3.0",
     "mocha": "^2.3.4",
     "mocha-eslint": "^1.0.0",
+    "snyk": "^1.1.0",
     "walk-sync": "^0.2.6"
   }
 }


### PR DESCRIPTION
Consumes of broccoli-sri-hash shouldn't be forced to run `snyk`.

I noticed this when getting the following message during `ember new foo`:

```
The use of Snyk's API, whether through the use of the 'snyk' npm package
or otherwise, is subject to the terms & conditions specified here: 
https://snyk.io/policies/customer-agreement.pdf
```
