### PR TITLE
Removing paranoiaCheck as fix is now in chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This plugin looks at an apps html files to rewrite their content with integrity 
         - `use-credentials`
         - `anonymous`
 - **prepend** - resources with a full path will only get an applied integrity if the md5 checksum passes
-- **paranoiaCheck** - true by default, this turns off the integrity attribute if any Unicode is found within the file.
+- **paranoiaCheck** - false by default, this turns off the integrity attribute if any Unicode is found within the file.
 
 ### Example
 ```js
@@ -26,6 +26,6 @@ var sriTree = sri('path/to/code', {
 
 ### 'paranoiaCheck'
 
-Currently there is an encoding issue based on certain characters which is [still being debugged](https://code.google.com/p/chromium/issues/detail?id=527286) when using Chrome.
+There was an encoding issue based on certain characters which is [landed in Chrome 46](https://code.google.com/p/chromium/issues/detail?id=527286) when using Chrome.
 This check fails if there is any non ASCII characters. On failure the file won't have a integrity attribute added.
 **Please note** this will be removed as a default in the future; with the desire to remove all of the checking code too.

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function SRIHashAssets(inputNodes, options) {
     // ]
   });
 
-  this.options.paranoiaCheck = this.options.paranoiaCheck || true;
+  this.options.paranoiaCheck = this.options.paranoiaCheck || false;
 
   if ('origin' in this.options) {
     if ('prefix' in this.options && !('crossorigin' in this.options)) {
@@ -117,7 +117,6 @@ SRIHashAssets.prototype.readFile = function readFile(dirname, file) {
 };
 
 /*
-  This check is always called (at the moment).
   If 'paranoiaCheck' is enabled then it will check a file only contains ASCII characters
     - will return true if paranoiaCheck is disabled
     - will return true if ASCII only

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-sri-hash",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Generates SRI hashes for html files",
   "main": "index.js",
   "scripts": {

--- a/test/fixtures/output/foo/test.html
+++ b/test/fixtures/output/foo/test.html
@@ -18,8 +18,8 @@
 
 <!-- scripts -->
 <script src="thing.js" integrity="sha256-oFeuE/P+XJMjkMS5pAPudQOMGJQ323nQt+DQ+9zbdAg= sha512-+EXjzt0I7g6BjvqqjkkboGyRlFSfIuyzY2SQ43HQKZBrHsjmRzEdjSHhiDzVs30nXL9H0tKw6WbMPc6RfzUumQ==" ></script>
-<script src="moment-with-locales.min.js"></script>
-<script src="unicode-chars.js"></script>
+<script src="moment-with-locales.min.js" integrity="sha256-adEQi08YTCIPXDx3gLrzleQ2ef3FlUksl0mQYn1I/lk= sha512-2qJOfXJTZ0mFzFAgq4GHE987uVW9jr931lRCs+QGjBuNbrzZ7nkZQZUW4esCNK2sDRc39k05Cudjzj2RfY2fyg==" ></script>
+<script src="unicode-chars.js" integrity="sha256-TH5eRuwfOSKZE0EKVF4WZ6gVQ/zUch4CZE2knqpS4MU= sha512-eANuTl8NOQEa4/zm44zxX6g7ffwf6NXftA2sv4ZiQURnJsfJkUnYP8XpN2XVVZee4SjB32i28WM6trs9HVgQmA==" ></script>
 <script srsc="unicode-chars.js"></script>
 <script s="unicode-chars.js"></script>
 <script src="https://example.com/thing-5e1978f9cfa158d9841d7b6d8a4e5c57.js" integrity="sha256-oFeuE/P+XJMjkMS5pAPudQOMGJQ323nQt+DQ+9zbdAg= sha512-+EXjzt0I7g6BjvqqjkkboGyRlFSfIuyzY2SQ43HQKZBrHsjmRzEdjSHhiDzVs30nXL9H0tKw6WbMPc6RfzUumQ==" crossorigin="anonymous"  ></script>

--- a/test/fixtures/output/test.html
+++ b/test/fixtures/output/test.html
@@ -16,8 +16,8 @@
 
 <!-- scripts -->
 <script src="thing.js" integrity="sha256-oFeuE/P+XJMjkMS5pAPudQOMGJQ323nQt+DQ+9zbdAg= sha512-+EXjzt0I7g6BjvqqjkkboGyRlFSfIuyzY2SQ43HQKZBrHsjmRzEdjSHhiDzVs30nXL9H0tKw6WbMPc6RfzUumQ==" ></script>
-<script src="moment-with-locales.min.js"></script>
-<script src="unicode-chars.js"></script>
+<script src="moment-with-locales.min.js" integrity="sha256-adEQi08YTCIPXDx3gLrzleQ2ef3FlUksl0mQYn1I/lk= sha512-2qJOfXJTZ0mFzFAgq4GHE987uVW9jr931lRCs+QGjBuNbrzZ7nkZQZUW4esCNK2sDRc39k05Cudjzj2RfY2fyg==" ></script>
+<script src="unicode-chars.js" integrity="sha256-TH5eRuwfOSKZE0EKVF4WZ6gVQ/zUch4CZE2knqpS4MU= sha512-eANuTl8NOQEa4/zm44zxX6g7ffwf6NXftA2sv4ZiQURnJsfJkUnYP8XpN2XVVZee4SjB32i28WM6trs9HVgQmA==" ></script>
 <script srsc="unicode-chars.js"></script>
 <script s="unicode-chars.js"></script>
 <script src="https://example.com/thing-5e1978f9cfa158d9841d7b6d8a4e5c57.js" integrity="sha256-oFeuE/P+XJMjkMS5pAPudQOMGJQ323nQt+DQ+9zbdAg= sha512-+EXjzt0I7g6BjvqqjkkboGyRlFSfIuyzY2SQ43HQKZBrHsjmRzEdjSHhiDzVs30nXL9H0tKw6WbMPc6RfzUumQ==" crossorigin="anonymous"  ></script>

--- a/test/fixtures/output2/test.html
+++ b/test/fixtures/output2/test.html
@@ -16,8 +16,8 @@
 
 <!-- scripts -->
 <script src="thing.js" integrity="sha256-oFeuE/P+XJMjkMS5pAPudQOMGJQ323nQt+DQ+9zbdAg= sha512-+EXjzt0I7g6BjvqqjkkboGyRlFSfIuyzY2SQ43HQKZBrHsjmRzEdjSHhiDzVs30nXL9H0tKw6WbMPc6RfzUumQ==" ></script>
-<script src="moment-with-locales.min.js"></script>
-<script src="unicode-chars.js"></script>
+<script src="moment-with-locales.min.js" integrity="sha256-adEQi08YTCIPXDx3gLrzleQ2ef3FlUksl0mQYn1I/lk= sha512-2qJOfXJTZ0mFzFAgq4GHE987uVW9jr931lRCs+QGjBuNbrzZ7nkZQZUW4esCNK2sDRc39k05Cudjzj2RfY2fyg==" ></script>
+<script src="unicode-chars.js" integrity="sha256-TH5eRuwfOSKZE0EKVF4WZ6gVQ/zUch4CZE2knqpS4MU= sha512-eANuTl8NOQEa4/zm44zxX6g7ffwf6NXftA2sv4ZiQURnJsfJkUnYP8XpN2XVVZee4SjB32i28WM6trs9HVgQmA==" ></script>
 <script srsc="unicode-chars.js"></script>
 <script s="unicode-chars.js"></script>
 <script src="https://example.com/thing-5e1978f9cfa158d9841d7b6d8a4e5c57.js" integrity="sha256-oFeuE/P+XJMjkMS5pAPudQOMGJQ323nQt+DQ+9zbdAg= sha512-+EXjzt0I7g6BjvqqjkkboGyRlFSfIuyzY2SQ43HQKZBrHsjmRzEdjSHhiDzVs30nXL9H0tKw6WbMPc6RfzUumQ==" crossorigin="anonymous"  ></script>


### PR DESCRIPTION
@stefanpenner and @rwjblue as we now have a Chrome that has a stable SRI this should be safe to push in.
