### PR TITLE
Enforce UTF-8 semantics while working with assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ SRIHashAssets.prototype.readFile = function readFile(dirname, file) {
   var assetSource;
 
   try {
-    assetSource = fs.readFileSync(dirname + '/' + file).toString();
+    assetSource = fs.readFileSync(dirname + '/' + file, 'utf8');
   } catch(e) {
     return null;
   }
@@ -201,7 +201,7 @@ SRIHashAssets.prototype.checkExternal = function checkExternal(output, file, dir
     }
   }
 
-  md5sum.update(assetSource);
+  md5sum.update(assetSource, 'utf8');
   if (md5Matches[2] === md5sum.digest('hex')) {
     return this.generateIntegrity(output, filePath, dirname, true);
   }
@@ -224,7 +224,7 @@ SRIHashAssets.prototype.mungeOutput = function mungeOutput(output, filePath, src
 
 SRIHashAssets.prototype.processHTMLFile = function processFile(entry) {
   var srcDir = path.dirname(entry.fullPath);
-  var fileContent = this.addSRI(fs.readFileSync(entry.fullPath,'UTF-8'), srcDir);
+  var fileContent = this.addSRI(fs.readFileSync(entry.fullPath, 'utf8'), srcDir);
   var fullPath = this.outputPath + '/' + entry.relativePath;
 
   mkdirp.sync(path.dirname(fullPath));


### PR DESCRIPTION
(N.B. This PR address jonathanKingston/ember-cli-sri#20.)

readFile() is reading the file (with Kernel#readFileSync()) as binary
data but implicitly converting the buffer to a utf8 string by calling
Buffer#toString() on it. Presumably, this is being done to in order to
implement paranoiaCheck, which scans the file one character at a time,
looking for non-ASCII characters. Later, this utf8 string is being
checksummed, but the call to Hash#update is implictly using binary
encoding. This is in contrast to broccoli-asset-rev, which reads the
file as binary data and calls Hash#update on the buffer (with implicit
binary encoding). If the file contain utf8 characters, the checksums
don't match!

To resolve this issue, let's read the file as a utf8 string, explicitly,
and then inform Hash#update that we are checksumming utf8 data. Now the
checksums match!

I also adjusted a call to Kernel#readFileSync() elsewhere to be
consistent (use 'utf8' instead of 'UTF-8' per the Node documentation).
