### PR TITLE
Use inputPath + relative file path instead of <base href>

### DIFF
--- a/test/fixtures/input/two/deep/test.html
+++ b/test/fixtures/input/two/deep/test.html
@@ -1,0 +1,32 @@
+<base href="/app/">
+
+<!-- styles -->
+<link rel="stylesheet" href="https://example.com/thing.css">
+<link rel="stylesheet" href="https://example.com/thing.css">
+<link rel="stylesheet" href="vendor.css" />
+<link rel="stylesheet" href="other.css" />
+<link rel="stylesheet" hresf="other.css" />
+<link href="other.css" />
+<linkhref="other.css" rel="stylesheet" />
+<link h="other.css" rel="stylesheet"  />
+<link hsref="other.css" rel="stylesheet" />
+<link href="other.css" rel="stylesheet" />
+<link href="other.css" rel="stylesheet" >
+<link href="other.css" rel="stylesheet">
+<link rel="stylesheet" href="https://example.com/vendor.css" />
+<link rel="stylesheet" href="https://subdomain.cloudfront.net/assets/vendor-d41d8cd98f00b204e9800998ecf8427e.css">
+
+<!-- scripts -->
+<script src="thing.js"></script>
+<script src="moment-with-locales.min.js"></script>
+<script src="unicode-chars.js"></script>
+<script srsc="unicode-chars.js"></script>
+<script s="unicode-chars.js"></script>
+<script src="https://example.com/thing-5e1978f9cfa158d9841d7b6d8a4e5c57.js"></script>
+<script src="https://example.com/thing-5e1978f9cfa158d9841d7b6d8a4e5c57.js" ></script>
+<script src="https://example.com/thing-5e1978f9cfa158d9841d7b6d8a4e5c57.js" crossorigin="use-credentials" ></script>
+<script src="https://example.com/thing"></script>
+<script src="https://example.com/thing" integrity="thing"></script>
+
+<!-- other -->
+<link rel="icon" type="image/png" href="favicon.png" sizes="16x16" />

--- a/test/fixtures/output/two/deep/test.html
+++ b/test/fixtures/output/two/deep/test.html
@@ -1,0 +1,32 @@
+<base href="/app/">
+
+<!-- styles -->
+<link rel="stylesheet" href="https://example.com/thing.css">
+<link rel="stylesheet" href="https://example.com/thing.css">
+<link rel="stylesheet" href="vendor.css" />
+<link rel="stylesheet" href="other.css" integrity="sha256-XgGI+esC0dkjsvC9cEqmQcHBWj7I6t+f24SPjtLYJxQ= sha512-KDs3Tn6m3NFDJscGjWvcD3gzxvt1H+QizMN+5GbiYi7hiTMIxbXd+ptD8857TTWcTJtZvwVZCD3BHqjmPZeVTA==" />
+<link rel="stylesheet" hresf="other.css" />
+<link href="other.css" />
+<linkhref="other.css" rel="stylesheet" />
+<link h="other.css" rel="stylesheet"  />
+<link hsref="other.css" rel="stylesheet" />
+<link href="other.css" rel="stylesheet" integrity="sha256-XgGI+esC0dkjsvC9cEqmQcHBWj7I6t+f24SPjtLYJxQ= sha512-KDs3Tn6m3NFDJscGjWvcD3gzxvt1H+QizMN+5GbiYi7hiTMIxbXd+ptD8857TTWcTJtZvwVZCD3BHqjmPZeVTA==" />
+<link href="other.css" rel="stylesheet" integrity="sha256-XgGI+esC0dkjsvC9cEqmQcHBWj7I6t+f24SPjtLYJxQ= sha512-KDs3Tn6m3NFDJscGjWvcD3gzxvt1H+QizMN+5GbiYi7hiTMIxbXd+ptD8857TTWcTJtZvwVZCD3BHqjmPZeVTA==" >
+<link href="other.css" rel="stylesheet" integrity="sha256-XgGI+esC0dkjsvC9cEqmQcHBWj7I6t+f24SPjtLYJxQ= sha512-KDs3Tn6m3NFDJscGjWvcD3gzxvt1H+QizMN+5GbiYi7hiTMIxbXd+ptD8857TTWcTJtZvwVZCD3BHqjmPZeVTA==" >
+<link rel="stylesheet" href="https://example.com/vendor.css" />
+<link rel="stylesheet" href="https://subdomain.cloudfront.net/assets/vendor-d41d8cd98f00b204e9800998ecf8427e.css">
+
+<!-- scripts -->
+<script src="thing.js" integrity="sha256-oFeuE/P+XJMjkMS5pAPudQOMGJQ323nQt+DQ+9zbdAg= sha512-+EXjzt0I7g6BjvqqjkkboGyRlFSfIuyzY2SQ43HQKZBrHsjmRzEdjSHhiDzVs30nXL9H0tKw6WbMPc6RfzUumQ==" ></script>
+<script src="moment-with-locales.min.js" integrity="sha256-adEQi08YTCIPXDx3gLrzleQ2ef3FlUksl0mQYn1I/lk= sha512-2qJOfXJTZ0mFzFAgq4GHE987uVW9jr931lRCs+QGjBuNbrzZ7nkZQZUW4esCNK2sDRc39k05Cudjzj2RfY2fyg==" ></script>
+<script src="unicode-chars.js" integrity="sha256-TH5eRuwfOSKZE0EKVF4WZ6gVQ/zUch4CZE2knqpS4MU= sha512-eANuTl8NOQEa4/zm44zxX6g7ffwf6NXftA2sv4ZiQURnJsfJkUnYP8XpN2XVVZee4SjB32i28WM6trs9HVgQmA==" ></script>
+<script srsc="unicode-chars.js"></script>
+<script s="unicode-chars.js"></script>
+<script src="https://example.com/thing-5e1978f9cfa158d9841d7b6d8a4e5c57.js" integrity="sha256-oFeuE/P+XJMjkMS5pAPudQOMGJQ323nQt+DQ+9zbdAg= sha512-+EXjzt0I7g6BjvqqjkkboGyRlFSfIuyzY2SQ43HQKZBrHsjmRzEdjSHhiDzVs30nXL9H0tKw6WbMPc6RfzUumQ==" crossorigin="anonymous"  ></script>
+<script src="https://example.com/thing-5e1978f9cfa158d9841d7b6d8a4e5c57.js" integrity="sha256-oFeuE/P+XJMjkMS5pAPudQOMGJQ323nQt+DQ+9zbdAg= sha512-+EXjzt0I7g6BjvqqjkkboGyRlFSfIuyzY2SQ43HQKZBrHsjmRzEdjSHhiDzVs30nXL9H0tKw6WbMPc6RfzUumQ==" crossorigin="anonymous"  ></script>
+<script src="https://example.com/thing-5e1978f9cfa158d9841d7b6d8a4e5c57.js" crossorigin="use-credentials" integrity="sha256-oFeuE/P+XJMjkMS5pAPudQOMGJQ323nQt+DQ+9zbdAg= sha512-+EXjzt0I7g6BjvqqjkkboGyRlFSfIuyzY2SQ43HQKZBrHsjmRzEdjSHhiDzVs30nXL9H0tKw6WbMPc6RfzUumQ==" ></script>
+<script src="https://example.com/thing"></script>
+<script src="https://example.com/thing" integrity="thing"></script>
+
+<!-- other -->
+<link rel="icon" type="image/png" href="favicon.png" sizes="16x16" />

--- a/test/fixtures/output2/two/deep/test.html
+++ b/test/fixtures/output2/two/deep/test.html
@@ -1,0 +1,30 @@
+<!-- styles -->
+<link rel="stylesheet" href="https://example.com/thing.css">
+<link rel="stylesheet" href="https://example.com/thing.css">
+<link rel="stylesheet" href="vendor.css" />
+<link rel="stylesheet" href="other.css" integrity="sha256-ZRXDQAaaiAOOtUbmDL5Ty2JR8Zf1AonXn6DCmchNhvk= sha512-dtOFpumNJPKES8S72UuTAXS6daEMYQKpRpCzlFAto/DHdx7fH0KK8sO9LjLpOjVWrDXE4G+MtisGdWa19wieSg==" />
+<link rel="stylesheet" hresf="other.css" />
+<link href="other.css" />
+<linkhref="other.css" rel="stylesheet" />
+<link h="other.css" rel="stylesheet"  />
+<link hsref="other.css" rel="stylesheet" />
+<link href="other.css" rel="stylesheet" integrity="sha256-ZRXDQAaaiAOOtUbmDL5Ty2JR8Zf1AonXn6DCmchNhvk= sha512-dtOFpumNJPKES8S72UuTAXS6daEMYQKpRpCzlFAto/DHdx7fH0KK8sO9LjLpOjVWrDXE4G+MtisGdWa19wieSg==" />
+<link href="other.css" rel="stylesheet" integrity="sha256-ZRXDQAaaiAOOtUbmDL5Ty2JR8Zf1AonXn6DCmchNhvk= sha512-dtOFpumNJPKES8S72UuTAXS6daEMYQKpRpCzlFAto/DHdx7fH0KK8sO9LjLpOjVWrDXE4G+MtisGdWa19wieSg==" >
+<link href="other.css" rel="stylesheet" integrity="sha256-ZRXDQAaaiAOOtUbmDL5Ty2JR8Zf1AonXn6DCmchNhvk= sha512-dtOFpumNJPKES8S72UuTAXS6daEMYQKpRpCzlFAto/DHdx7fH0KK8sO9LjLpOjVWrDXE4G+MtisGdWa19wieSg==" >
+<link rel="stylesheet" href="https://example.com/vendor.css" />
+<link rel="stylesheet" href="https://subdomain.cloudfront.net/assets/vendor-d41d8cd98f00b204e9800998ecf8427e.css">
+
+<!-- scripts -->
+<script src="thing.js" integrity="sha256-oFeuE/P+XJMjkMS5pAPudQOMGJQ323nQt+DQ+9zbdAg= sha512-+EXjzt0I7g6BjvqqjkkboGyRlFSfIuyzY2SQ43HQKZBrHsjmRzEdjSHhiDzVs30nXL9H0tKw6WbMPc6RfzUumQ==" ></script>
+<script src="moment-with-locales.min.js"></script>
+<script src="unicode-chars.js"></script>
+<script srsc="unicode-chars.js"></script>
+<script s="unicode-chars.js"></script>
+<script src="https://example.com/thing-5e1978f9cfa158d9841d7b6d8a4e5c57.js" integrity="sha256-oFeuE/P+XJMjkMS5pAPudQOMGJQ323nQt+DQ+9zbdAg= sha512-+EXjzt0I7g6BjvqqjkkboGyRlFSfIuyzY2SQ43HQKZBrHsjmRzEdjSHhiDzVs30nXL9H0tKw6WbMPc6RfzUumQ==" crossorigin="anonymous"  ></script>
+<script src="https://example.com/thing-5e1978f9cfa158d9841d7b6d8a4e5c57.js" integrity="sha256-oFeuE/P+XJMjkMS5pAPudQOMGJQ323nQt+DQ+9zbdAg= sha512-+EXjzt0I7g6BjvqqjkkboGyRlFSfIuyzY2SQ43HQKZBrHsjmRzEdjSHhiDzVs30nXL9H0tKw6WbMPc6RfzUumQ==" crossorigin="anonymous"  ></script>
+<script src="https://example.com/thing-5e1978f9cfa158d9841d7b6d8a4e5c57.js" crossorigin="use-credentials" integrity="sha256-oFeuE/P+XJMjkMS5pAPudQOMGJQ323nQt+DQ+9zbdAg= sha512-+EXjzt0I7g6BjvqqjkkboGyRlFSfIuyzY2SQ43HQKZBrHsjmRzEdjSHhiDzVs30nXL9H0tKw6WbMPc6RfzUumQ==" ></script>
+<script src="https://example.com/thing"></script>
+<script src="https://example.com/thing" integrity="thing"></script>
+
+<!-- other -->
+<link rel="icon" type="image/png" href="favicon.png" sizes="16x16" />

--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,11 @@ describe('broccoli-sri-hash', function () {
 
       assert.equal(actual, expected);
 
+      actual = file(output.directory + '/two/deep/test.html');
+      expected = file('test/fixtures/output/two/deep/test.html');
+
+      assert.equal(actual, expected);
+
       assert.deepEqual(walkSync(output.directory), [
         'favicon.png',
         'foo/',
@@ -47,6 +52,9 @@ describe('broccoli-sri-hash', function () {
         'other.css',
         'test.html',
         'thing.js',
+        'two/',
+        'two/deep/',
+        'two/deep/test.html',
         'unicode-chars.js'
       ]);
     });
@@ -68,6 +76,9 @@ describe('broccoli-sri-hash', function () {
         'other.css',
         'test.html',
         'thing.js',
+        'two/',
+        'two/deep/',
+        'two/deep/test.html',
         'unicode-chars.js'
       ]);
       return builder.build();
@@ -84,6 +95,9 @@ describe('broccoli-sri-hash', function () {
         'other.css',
         'test.html',
         'thing.js',
+        'two/',
+        'two/deep/',
+        'two/deep/test.html',
         'unicode-chars.js'
       ]);
       assert.equal(actual, expected);


### PR DESCRIPTION
#### Context
#12 had the unfortunate side-effect of breaking SRI for apps that use a `baseURL` that isn't `/` (see: https://github.com/jonathanKingston/ember-cli-sri/issues/18)
#### Proposal

Use the plugin's input path (`this.inputPath[0]`) along with the relative path and filename that's extracted from the tag that's having its `integrity` attribute computed.

I've tested this strategy against `ember-cli-sri` and its tests pass.  I've also tested against an app that uses a `baseURL` of `/` and one that uses  `/app/` and the SRI attributes are generated correctly in both cases for both production and test builds.

This seems like a good fix to me, but I'm ready for the shaming if I've missed something obvious...
