### PR TITLE
Allow single-quoted src and rel in scripts and style

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ version: "{build}"
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "0.12"
+    - nodejs_version: "8"
 
 install:
   # Get the latest stable version of Node 0.STABLE.latest

--- a/index.js
+++ b/index.js
@@ -6,12 +6,12 @@ var symlinkOrCopy = require('symlink-or-copy').sync;
 var Promise = require('rsvp').Promise; // node 0.10
 var path = require('path');
 
-var STYLE_CHECK = /\srel=["\'][^"]*stylesheet[^"]*["\']/;
+var STYLE_CHECK = /\srel=["\'][^"\']*stylesheet[^"\']*["\']/;
 var SRC_CHECK = /\ssrc=["\']([^"\']+)["\']/;
 var HREF_CHECK = /\shref=["\']([^"\']+)["\']/;
-var BASE_CHECK = new RegExp('<base[^>]*href=["\']([^"]*)["\'][^>]*>', 'g');
-var SCRIPT_CHECK = new RegExp('<script[^>]*src=["\']([^"]*)["\'][^>]*>', 'g');
-var LINT_CHECK = new RegExp('<link[^>]*href=["\']([^"]*)["\'][^>]*>', 'g');
+var BASE_CHECK = new RegExp('<base[^>]*href=["\']([^"\']*)["\'][^>]*>', 'g');
+var SCRIPT_CHECK = new RegExp('<script[^>]*src=["\']([^"\']*)["\'][^>]*>', 'g');
+var LINT_CHECK = new RegExp('<link[^>]*href=["\']([^"\']*)["\'][^>]*>', 'g');
 var INTEGRITY_CHECK = new RegExp('integrity=["\']');
 var CROSS_ORIGIN_CHECK = new RegExp('crossorigin=["\']([^"\']+)["\']');
 var MD5_CHECK = /^(.*)[-]([a-z0-9]{32})([.].*)$/;


### PR DESCRIPTION
Scripts that used single quotes such as this one had extremely buggy behavior:

```html
<script src='first.js'></script>
<script src='second.js'></script>
```

… were converted to this:

```html
<script src='first.js'></script>
<script src='second.js' integrity="hash of first.js"></script>
```

Having double-quotes instead:

```html
<script src="first.js"></script>
<script src="second.js"></script>
```

… gave the correct result:

```html
<script src="first.js" integrity="hash of first.js"></script>
<script src="second.js" integrity="hash of second.js"></script>
```

This patch corrects the bug described here when using single quotes, yielding the following result, as expected:

```html
<script src='first.js' integrity="hash of first.js"></script>
<script src='second.js' integrity="hash of second.js"></script>
```